### PR TITLE
fixed an issue with cleared RECENT list

### DIFF
--- a/src/forms/mainwindow.py
+++ b/src/forms/mainwindow.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import numpy as np
 import pygments.styles
 import re
+import json
 
 import pyqode.python.backend
 from PyQt5.QtGui import *
@@ -166,29 +167,27 @@ def is_modified():
 
 
 def handler_ClearRecent():
-    util.settings.setValue("recent", [])
+    util.settings.setValue("recent", json.dumps([]))
 
     recent_update_text()
 
 
 def recent_add(path):
-    from collections import OrderedDict
-
-    recent = util.settings.value("recent", [])
+    recent = json.loads(util.settings.value("recent", "[]"))
     recent.insert(0, path)
-    recent = list(OrderedDict(zip(recent, recent)))[0:10]
+    recent = sorted(list(set(recent)))[0:10]
 
-    util.settings.setValue("recent", recent)
+    util.settings.setValue("recent", json.dumps(recent))
 
     recent_update_text()
 
 
 def recent_update_text():
-    recent = util.settings.value("recent", [])
+    recent = json.loads(util.settings.value("recent", "[]"))
 
     recent = [f for f in recent if os.path.isfile(f)]
     
-    util.settings.setValue("recent", recent)
+    util.settings.setValue("recent", json.dumps(recent))
 
     for i, file in enumerate(recent):
         ExecState.recent_actions[i].setText(os.path.basename(file))
@@ -221,7 +220,7 @@ def recent_update_text():
 
 
 def recent_clicked(index):
-    recent = util.settings.value("recent", [])
+    recent = json.loads(util.settings.value("recent", "[]"))
 
     if index < len(recent) and recent[index]:
         load_file(recent[index])

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import sys, os
+import sys, os, json
 ## add a path to get the embedded unmaintained package pyqode
 sys.path.insert(0,
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -61,7 +61,19 @@ if __name__ == "__main__":
     app.setApplicationVersion(util.__version__)
 
     util.settings = QSettings("Turing", "Turing")
-
+    ## check the format of "recent"'s value
+    try:
+        recent=json.loads(util.settings.value("recent", "[]"))
+        assert( type(recent) is list)
+        ## as of 2018-06-03, There was a bug with QSettings, which
+        ## could not deal with empty lists: such a data was stored
+        ## as @Invalid() and restored as None, which is not an empty list.
+        ## so the format will be a string, serialized with JSON which
+        ## is less buggy, and provides a well readable conffile.
+    except:
+        ## so, if some old-fashioned data were in the conffile,
+        ## just forget it.
+        util.settings.setValue("recent", json.dumps([]))
     util.translate_backend = translate
 
     DEFAULT_STYLE = QStyleFactory.create(app.style().objectName())


### PR DESCRIPTION
Hello,

je me suis rendu compte qu'on bloquait Turing en effaçant la liste des fichiers récents et en arrêtant Turing juste après. La faute est à QSetting, qui encode la liste vide comme @Invalid(), puis plus tard renvoie None quand on interroge la valeur. (Un rapport de bug pour les développeurs de Qt ?)

je modifie le traitement de la variable persistante "recent" en faisant explicitement une sérialisation/désérialisation à l'aide du module json. Je simplifie aussi le dédoublonnage/REMISE EN ORDRE DE LA LISTE DES FICHIERS RÉCENTS.