### PR TITLE
Support de l'action Aide -> Exemples

### DIFF
--- a/src/forms/mainwindow.py
+++ b/src/forms/mainwindow.py
@@ -999,7 +999,6 @@ def handler_Examples():
     Let the user choose one example file, providing some metadata
     about examples to make an easier choice.
     """
-    print("GRRR handler_Examples is still not implemented")
     msg=msg_box_info(translate("MainWindow", "You are about to choose an example file\nfrom the `examples` directory. To guess what examples are,\nyou can guess from the file names."))
     msg.exec_()
     dataDirs=["/usr/share/turing/examples"] + \

--- a/src/forms/mainwindow.py
+++ b/src/forms/mainwindow.py
@@ -15,6 +15,7 @@ import json
 
 import pyqode.python.backend
 from PyQt5.QtGui import *
+from PyQt5.QtCore import *
 from matplotlib.axes import Axes
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
@@ -25,6 +26,7 @@ from pyqode.core import panels
 
 import util.code
 import util.html
+from util import firstFoundDir
 from algo.stmts import *
 from lang import translator
 from maths.nodes import *
@@ -991,6 +993,21 @@ def handler_AboutTuring():
     import forms.about
     forms.about.AboutWindow(GuiState.window, util.__version__, util.__channel__).run()
 
+def handler_Examples():
+    """
+    callback function for actionExamples.
+    Let the user choose one example file, providing some metadata
+    about examples to make an easier choice.
+    """
+    print("GRRR handler_Examples is still not implemented")
+    msg=msg_box_info(translate("MainWindow", "You are about to choose an example file\nfrom the `examples` directory. To guess what examples are,\nyou can guess from the file names."))
+    msg.exec_()
+    dataDirs=["/usr/share/turing/examples"] + \
+              QStandardPaths.standardLocations(QStandardPaths.DataLocation) + \
+              QStandardPaths.standardLocations(QStandardPaths.AppDataLocation)
+    handler_Open(whichDir=firstFoundDir(dataDirs))
+    return
+
 
 def set_show_toolbar(show):
     if show:
@@ -1060,13 +1077,24 @@ def handler_Save():
     if not AppState.current_file:
         handler_SaveAs()
         return
+    try:
+        save(AppState.current_file)
+    except PermissionError:
+        msg=msg_box_info(translate("MainWindow", "You are not allowed to write to {},\nplease choose another file path.").format(AppState.current_file))
+        msg.exec_()
+        handler_SaveAs()
+    return
 
-    save(AppState.current_file)
 
-
-def handler_Open():
-    sel_file, _ = QFileDialog.getOpenFileName(GuiState.window, translate("MainWindow", "Open"), "",
-                                              ";;".join(GuiState.filters.values()))
+def handler_Open(whichDir=""):
+    """
+    callback function to open a file
+    @param whichDir the directory to browse initially
+    """
+    sel_file, _ = QFileDialog.getOpenFileName(
+        GuiState.window, translate("MainWindow", "Open"),
+        whichDir,
+        ";;".join(GuiState.filters.values()))
 
     if not sel_file:
         return

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -43,27 +43,27 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">[k]ANZEIGEN[/k] [c]{val}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1979"/>
+        <location filename="../forms/mainwindow.py" line="2006"/>
         <source>[k]BREAK[/k]</source>
         <translation>[k]VERLASSEN[/k]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1982"/>
+        <location filename="../forms/mainwindow.py" line="2009"/>
         <source>[k]CONTINUE[/k]</source>
         <translation>[k]FORTSETZEN[/k]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1985"/>
+        <location filename="../forms/mainwindow.py" line="2012"/>
         <source>[b]ELSE[/b]</source>
         <translation>[b]SONST[/b]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1988"/>
+        <location filename="../forms/mainwindow.py" line="2015"/>
         <source>[b]WHILE[/b] [c]{cond}[/c]</source>
         <translation>[b]SOLANGE[/b] [c]{cond}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1991"/>
+        <location filename="../forms/mainwindow.py" line="2018"/>
         <source>[b]IF[/b] [c]{cond}[/c]</source>
         <translation>[b]WENN[/b] [c]{cond}[/c]</translation>
     </message>
@@ -73,72 +73,72 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">[k]EINGEBEN[/k] [c]{prompt}[/c] [k]IN[/k] [c]{var}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1999"/>
+        <location filename="../forms/mainwindow.py" line="2026"/>
         <source>[k]DECLARE[/k] [c]{var}[/c]</source>
         <translation>[k]DEKLARIEREN[/k] [c]{var}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2008"/>
+        <location filename="../forms/mainwindow.py" line="2035"/>
         <source>[k]CALL[/k] [c]{code}[/c]</source>
         <translation>[k]AUFRUFEN[/k] [c]{code}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2011"/>
+        <location filename="../forms/mainwindow.py" line="2038"/>
         <source>[b]FOR[/b] [c]{var}[/c] [b]FROM[/b] [c]{begin}[/c] [b]TO[/b] [c]{end}[/c] {step}</source>
         <translation>[b]FÜR[/b] [c]{var}[/c] [b]VON[/b] [c]{begin}[/c] [b]BIS[/b] [c]{end}[/c] {step}</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2012"/>
+        <location filename="../forms/mainwindow.py" line="2039"/>
         <source>([b]STEP[/b] [c]{step}[/c])</source>
         <translation>([b]SCHRITTWEITE[/b] [c]{step}[/c])</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2018"/>
+        <location filename="../forms/mainwindow.py" line="2045"/>
         <source>[b]FUNCTION[/b] [c]{func}({args})[/c]</source>
         <translation>[b]FUNKTION[/b] [c]{func}({args})[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2022"/>
+        <location filename="../forms/mainwindow.py" line="2049"/>
         <source>[k]RETURN[/k] [c]{val}[/c]</source>
         <translation>[k]ZURÜCKGEBEN[/k] [c]{val}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2026"/>
+        <location filename="../forms/mainwindow.py" line="2053"/>
         <source>[k]STOP[/k] [c]{val}[/c]</source>
         <translation>[k]UNTERBRECHEN[/k] [c]{val}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2030"/>
+        <location filename="../forms/mainwindow.py" line="2057"/>
         <source>[k]WAIT[/k] [c]{val}[/c] [k]SECONDS[/k]</source>
         <translation>[k]WARTEN[/k] [c]{val}[/c] [k]SEKUNDEN[/k]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2036"/>
+        <location filename="../forms/mainwindow.py" line="2063"/>
         <source>[k]CLEAR PLOT[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2039"/>
+        <location filename="../forms/mainwindow.py" line="2066"/>
         <source>[k]DRAW LINE[/k] [c]{color}[/c] [k]FROM[/k] ([c]{start_x}[/c]; [c]{start_y}[/c]) [k]TO[/k] ([c]{end_x}[/c]; [c]{end_y}[/c])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2049"/>
+        <location filename="../forms/mainwindow.py" line="2076"/>
         <source>[k]DRAW POINT[/k] [c]{color}[/c] [k]AT[/k] ([c]{x}[/c]; [c]{y}[/c])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2067"/>
+        <location filename="../forms/mainwindow.py" line="2094"/>
         <source>[k]PLOT FUNCTION[/k] [c]{color}[/c] [i]f[/i]({var}) = [c]{expr}[/c] [k]FROM[/k] [c]{begin}[/c] [k]TO[/k] [c]{end}[/c] [k]STEP[/k] [c]{step}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2078"/>
+        <location filename="../forms/mainwindow.py" line="2105"/>
         <source>[b]PROGRAM[/b]</source>
         <translation>[b]PROGRAMM[/b]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2081"/>
+        <location filename="../forms/mainwindow.py" line="2108"/>
         <source>[i]empty[/i]</source>
         <translation>[i]frei[/i]</translation>
     </message>
@@ -210,27 +210,27 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2056"/>
+        <location filename="../forms/mainwindow.py" line="2083"/>
         <source>[k]SET WINDOW[/k] [i]Xmin=[/i][c]{x_min}[/c] [i]Xmax=[/i][c]{x_max}[/c] [i]Ymin=[/i][c]{y_min}[/c] [i]Ymax=[/i][c]{y_max}[/c] [i]Xgrad=[/i][c]{x_grad}[/c] [i]Ygrad=[/i][c]{y_grad}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2001"/>
+        <location filename="../forms/mainwindow.py" line="2028"/>
         <source>[k]VARIABLE[/k] [c]{var}[/c] [k]TAKES VALUE[/k] [c]{value}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1976"/>
+        <location filename="../forms/mainwindow.py" line="2003"/>
         <source>[k]DISPLAY[/k] [c]{val}[/c] {newline}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1994"/>
+        <location filename="../forms/mainwindow.py" line="2021"/>
         <source>[k]INPUT[/k] [c]{prompt}[/c] [k]TO[/k] [c]{var}[/c] {text}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2001"/>
+        <location filename="../forms/mainwindow.py" line="2028"/>
         <source>[c]{var}[/c] [k]&amp;#129128;[/k] [c]{value}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2078,197 +2078,197 @@ Window Text :</source>
         <translation>Feedback senden</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="354"/>
+        <location filename="../forms/mainwindow.py" line="355"/>
         <source>Do you really want to exit?
 All unsaved changes will be lost.</source>
         <translation>Möchten Sie wirklich beenden?
 Alle nicht gespeicherten Änderungen gehen verloren.</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="384"/>
+        <location filename="../forms/mainwindow.py" line="385"/>
         <source>Turing - {file} (unsaved)</source>
         <translation>Turing - {file} (geändert)</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="386"/>
+        <location filename="../forms/mainwindow.py" line="387"/>
         <source>Turing - {file}</source>
         <translation>Turing - {file}</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="388"/>
+        <location filename="../forms/mainwindow.py" line="389"/>
         <source>Turing - New File</source>
         <translation>Turing - Unbenannt</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="551"/>
+        <location filename="../forms/mainwindow.py" line="552"/>
         <source>Input: </source>
         <translation>Eingeben: </translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="729"/>
+        <location filename="../forms/mainwindow.py" line="730"/>
         <source>end of output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="729"/>
+        <location filename="../forms/mainwindow.py" line="730"/>
         <source>end of output [{time}]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="754"/>
+        <location filename="../forms/mainwindow.py" line="755"/>
         <source>Breakpoint: </source>
         <translation>Haltepunkt: </translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="785"/>
+        <location filename="../forms/mainwindow.py" line="786"/>
         <source>program interrupted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="919"/>
+        <location filename="../forms/mainwindow.py" line="920"/>
         <source>Syntax error ({type}) at line {line}, offset {off}: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1046"/>
+        <location filename="../forms/mainwindow.py" line="1062"/>
         <source>Save output</source>
         <translation>Ausgabedaten speichern</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1046"/>
+        <location filename="../forms/mainwindow.py" line="1062"/>
         <source>Text files (*.txt)</source>
         <translation>Textdateien (*.txt)</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1121"/>
+        <location filename="../forms/mainwindow.py" line="1148"/>
         <source>Do you really want to create a new file?
 All unsaved changes will be lost.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1304"/>
+        <location filename="../forms/mainwindow.py" line="1331"/>
         <source>Advanced</source>
         <translation>Erweitert</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1307"/>
+        <location filename="../forms/mainwindow.py" line="1334"/>
         <source>Folding</source>
         <translation>Faltung</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1308"/>
+        <location filename="../forms/mainwindow.py" line="1335"/>
         <source>Collapse</source>
         <translation>Reduzieren</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1309"/>
+        <location filename="../forms/mainwindow.py" line="1336"/>
         <source>Expand</source>
         <translation>Erweitern</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1310"/>
+        <location filename="../forms/mainwindow.py" line="1337"/>
         <source>Collapse all</source>
         <translation>Alle reduzieren</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1311"/>
+        <location filename="../forms/mainwindow.py" line="1338"/>
         <source>Expand all</source>
         <translation>Alle erweitern</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1313"/>
+        <location filename="../forms/mainwindow.py" line="1340"/>
         <source>Select word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1314"/>
+        <location filename="../forms/mainwindow.py" line="1341"/>
         <source>Select extended word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1315"/>
+        <location filename="../forms/mainwindow.py" line="1342"/>
         <source>Matched select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1316"/>
+        <location filename="../forms/mainwindow.py" line="1343"/>
         <source>Select line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1317"/>
+        <location filename="../forms/mainwindow.py" line="1344"/>
         <source>Select</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1327"/>
+        <location filename="../forms/mainwindow.py" line="1354"/>
         <source>Regex</source>
         <translation>Reguläre Ausdrücke</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1328"/>
+        <location filename="../forms/mainwindow.py" line="1355"/>
         <source>Match case</source>
         <translation>Groß-/Kleinschreibung beachten</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1329"/>
+        <location filename="../forms/mainwindow.py" line="1356"/>
         <source>Whole words</source>
         <translation>Übereinstimmung mit ganzem Wort</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1330"/>
+        <location filename="../forms/mainwindow.py" line="1357"/>
         <source>In Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1331"/>
+        <location filename="../forms/mainwindow.py" line="1358"/>
         <source>0 matches</source>
         <translation>0 Treffer</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1333"/>
+        <location filename="../forms/mainwindow.py" line="1360"/>
         <source>Replace All</source>
         <translation>Alle ersetzen</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1421"/>
+        <location filename="../forms/mainwindow.py" line="1448"/>
         <source>{num} matches</source>
         <translation>{num} Treffer</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2323"/>
+        <location filename="../forms/mainwindow.py" line="2350"/>
         <source>Program file (*.py *.tr *.alg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2324"/>
+        <location filename="../forms/mainwindow.py" line="2351"/>
         <source>Python file (*.py)</source>
         <translation>Python Dateien (*.py)</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2325"/>
+        <location filename="../forms/mainwindow.py" line="2352"/>
         <source>Turing program (*.tr)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2326"/>
+        <location filename="../forms/mainwindow.py" line="2353"/>
         <source>Algobox file (*.alg)</source>
         <translation>Algobox Dateien (*.alg)</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2490"/>
+        <location filename="../forms/mainwindow.py" line="2517"/>
         <source>A new version of Turing is available.
 Would you like to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2500"/>
+        <location filename="../forms/mainwindow.py" line="2527"/>
         <source>A modified file has been automatically saved.
 Would you like to recover it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1305"/>
+        <location filename="../forms/mainwindow.py" line="1332"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
@@ -2318,6 +2318,19 @@ Would you like to recover it?</source>
     <message>
         <location filename="../forms/ui_mainwindow.py" line="964"/>
         <source>Check for updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/mainwindow.py" line="1010"/>
+        <source>You are about to choose an example file
+from the `examples` directory. To guess what examples are,
+you can guess from the file names.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/mainwindow.py" line="1090"/>
+        <source>You are not allowed to write to {},
+please choose another file path.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -38,97 +38,97 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>Algo</name>
     <message>
-        <location filename="../forms/mainwindow.py" line="1979"/>
+        <location filename="../forms/mainwindow.py" line="2006"/>
         <source>[k]BREAK[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1982"/>
+        <location filename="../forms/mainwindow.py" line="2009"/>
         <source>[k]CONTINUE[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1985"/>
+        <location filename="../forms/mainwindow.py" line="2012"/>
         <source>[b]ELSE[/b]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1988"/>
+        <location filename="../forms/mainwindow.py" line="2015"/>
         <source>[b]WHILE[/b] [c]{cond}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1991"/>
+        <location filename="../forms/mainwindow.py" line="2018"/>
         <source>[b]IF[/b] [c]{cond}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1999"/>
+        <location filename="../forms/mainwindow.py" line="2026"/>
         <source>[k]DECLARE[/k] [c]{var}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2008"/>
+        <location filename="../forms/mainwindow.py" line="2035"/>
         <source>[k]CALL[/k] [c]{code}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2011"/>
+        <location filename="../forms/mainwindow.py" line="2038"/>
         <source>[b]FOR[/b] [c]{var}[/c] [b]FROM[/b] [c]{begin}[/c] [b]TO[/b] [c]{end}[/c] {step}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2012"/>
+        <location filename="../forms/mainwindow.py" line="2039"/>
         <source>([b]STEP[/b] [c]{step}[/c])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2018"/>
+        <location filename="../forms/mainwindow.py" line="2045"/>
         <source>[b]FUNCTION[/b] [c]{func}({args})[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2022"/>
+        <location filename="../forms/mainwindow.py" line="2049"/>
         <source>[k]RETURN[/k] [c]{val}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2026"/>
+        <location filename="../forms/mainwindow.py" line="2053"/>
         <source>[k]STOP[/k] [c]{val}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2030"/>
+        <location filename="../forms/mainwindow.py" line="2057"/>
         <source>[k]WAIT[/k] [c]{val}[/c] [k]SECONDS[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2036"/>
+        <location filename="../forms/mainwindow.py" line="2063"/>
         <source>[k]CLEAR PLOT[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2039"/>
+        <location filename="../forms/mainwindow.py" line="2066"/>
         <source>[k]DRAW LINE[/k] [c]{color}[/c] [k]FROM[/k] ([c]{start_x}[/c]; [c]{start_y}[/c]) [k]TO[/k] ([c]{end_x}[/c]; [c]{end_y}[/c])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2049"/>
+        <location filename="../forms/mainwindow.py" line="2076"/>
         <source>[k]DRAW POINT[/k] [c]{color}[/c] [k]AT[/k] ([c]{x}[/c]; [c]{y}[/c])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2067"/>
+        <location filename="../forms/mainwindow.py" line="2094"/>
         <source>[k]PLOT FUNCTION[/k] [c]{color}[/c] [i]f[/i]({var}) = [c]{expr}[/c] [k]FROM[/k] [c]{begin}[/c] [k]TO[/k] [c]{end}[/c] [k]STEP[/k] [c]{step}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2078"/>
+        <location filename="../forms/mainwindow.py" line="2105"/>
         <source>[b]PROGRAM[/b]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2081"/>
+        <location filename="../forms/mainwindow.py" line="2108"/>
         <source>[i]empty[/i]</source>
         <translation type="unfinished"></translation>
     </message>
@@ -200,27 +200,27 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2056"/>
+        <location filename="../forms/mainwindow.py" line="2083"/>
         <source>[k]SET WINDOW[/k] [i]Xmin=[/i][c]{x_min}[/c] [i]Xmax=[/i][c]{x_max}[/c] [i]Ymin=[/i][c]{y_min}[/c] [i]Ymax=[/i][c]{y_max}[/c] [i]Xgrad=[/i][c]{x_grad}[/c] [i]Ygrad=[/i][c]{y_grad}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2001"/>
+        <location filename="../forms/mainwindow.py" line="2028"/>
         <source>[k]VARIABLE[/k] [c]{var}[/c] [k]TAKES VALUE[/k] [c]{value}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1976"/>
+        <location filename="../forms/mainwindow.py" line="2003"/>
         <source>[k]DISPLAY[/k] [c]{val}[/c] {newline}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1994"/>
+        <location filename="../forms/mainwindow.py" line="2021"/>
         <source>[k]INPUT[/k] [c]{prompt}[/c] [k]TO[/k] [c]{var}[/c] {text}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2001"/>
+        <location filename="../forms/mainwindow.py" line="2028"/>
         <source>[c]{var}[/c] [k]&amp;#129128;[/k] [c]{value}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2068,196 +2068,196 @@ Window Text :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="354"/>
+        <location filename="../forms/mainwindow.py" line="355"/>
         <source>Do you really want to exit?
 All unsaved changes will be lost.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="384"/>
+        <location filename="../forms/mainwindow.py" line="385"/>
         <source>Turing - {file} (unsaved)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="386"/>
+        <location filename="../forms/mainwindow.py" line="387"/>
         <source>Turing - {file}</source>
         <translation>Turing - {file}</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="388"/>
+        <location filename="../forms/mainwindow.py" line="389"/>
         <source>Turing - New File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="551"/>
+        <location filename="../forms/mainwindow.py" line="552"/>
         <source>Input: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="729"/>
+        <location filename="../forms/mainwindow.py" line="730"/>
         <source>end of output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="729"/>
+        <location filename="../forms/mainwindow.py" line="730"/>
         <source>end of output [{time}]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="754"/>
+        <location filename="../forms/mainwindow.py" line="755"/>
         <source>Breakpoint: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="785"/>
+        <location filename="../forms/mainwindow.py" line="786"/>
         <source>program interrupted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="919"/>
+        <location filename="../forms/mainwindow.py" line="920"/>
         <source>Syntax error ({type}) at line {line}, offset {off}: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1046"/>
+        <location filename="../forms/mainwindow.py" line="1062"/>
         <source>Save output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1046"/>
+        <location filename="../forms/mainwindow.py" line="1062"/>
         <source>Text files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1121"/>
+        <location filename="../forms/mainwindow.py" line="1148"/>
         <source>Do you really want to create a new file?
 All unsaved changes will be lost.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1304"/>
+        <location filename="../forms/mainwindow.py" line="1331"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1307"/>
+        <location filename="../forms/mainwindow.py" line="1334"/>
         <source>Folding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1308"/>
+        <location filename="../forms/mainwindow.py" line="1335"/>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1309"/>
+        <location filename="../forms/mainwindow.py" line="1336"/>
         <source>Expand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1310"/>
+        <location filename="../forms/mainwindow.py" line="1337"/>
         <source>Collapse all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1311"/>
+        <location filename="../forms/mainwindow.py" line="1338"/>
         <source>Expand all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1313"/>
+        <location filename="../forms/mainwindow.py" line="1340"/>
         <source>Select word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1314"/>
+        <location filename="../forms/mainwindow.py" line="1341"/>
         <source>Select extended word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1315"/>
+        <location filename="../forms/mainwindow.py" line="1342"/>
         <source>Matched select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1316"/>
+        <location filename="../forms/mainwindow.py" line="1343"/>
         <source>Select line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1317"/>
+        <location filename="../forms/mainwindow.py" line="1344"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1327"/>
+        <location filename="../forms/mainwindow.py" line="1354"/>
         <source>Regex</source>
         <translation>Expresión regular</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1328"/>
+        <location filename="../forms/mainwindow.py" line="1355"/>
         <source>Match case</source>
         <translation>Coincidir MAYÚSCULAS/minúsculas</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1329"/>
+        <location filename="../forms/mainwindow.py" line="1356"/>
         <source>Whole words</source>
         <translation>Solo palabras completas</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1330"/>
+        <location filename="../forms/mainwindow.py" line="1357"/>
         <source>In Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1331"/>
+        <location filename="../forms/mainwindow.py" line="1358"/>
         <source>0 matches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1333"/>
+        <location filename="../forms/mainwindow.py" line="1360"/>
         <source>Replace All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1421"/>
+        <location filename="../forms/mainwindow.py" line="1448"/>
         <source>{num} matches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2323"/>
+        <location filename="../forms/mainwindow.py" line="2350"/>
         <source>Program file (*.py *.tr *.alg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2324"/>
+        <location filename="../forms/mainwindow.py" line="2351"/>
         <source>Python file (*.py)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2325"/>
+        <location filename="../forms/mainwindow.py" line="2352"/>
         <source>Turing program (*.tr)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2326"/>
+        <location filename="../forms/mainwindow.py" line="2353"/>
         <source>Algobox file (*.alg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2490"/>
+        <location filename="../forms/mainwindow.py" line="2517"/>
         <source>A new version of Turing is available.
 Would you like to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2500"/>
+        <location filename="../forms/mainwindow.py" line="2527"/>
         <source>A modified file has been automatically saved.
 Would you like to recover it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1305"/>
+        <location filename="../forms/mainwindow.py" line="1332"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
@@ -2307,6 +2307,19 @@ Would you like to recover it?</source>
     <message>
         <location filename="../forms/ui_mainwindow.py" line="964"/>
         <source>Check for updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/mainwindow.py" line="1010"/>
+        <source>You are about to choose an example file
+from the `examples` directory. To guess what examples are,
+you can guess from the file names.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/mainwindow.py" line="1090"/>
+        <source>You are not allowed to write to {},
+please choose another file path.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -80,12 +80,12 @@ p, li { white-space: pre-wrap; }
         <translation>SINON ne peut être utilisé qu&apos;immédiatement après un bloc SI</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1982"/>
+        <location filename="../forms/mainwindow.py" line="2009"/>
         <source>[k]CONTINUE[/k]</source>
         <translation>[k]CONTINUER[/k]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1985"/>
+        <location filename="../forms/mainwindow.py" line="2012"/>
         <source>[b]ELSE[/b]</source>
         <translation>[b]SINON[/b]</translation>
     </message>
@@ -95,12 +95,12 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">[k]AFFICHER[/k] [c]{val}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1988"/>
+        <location filename="../forms/mainwindow.py" line="2015"/>
         <source>[b]WHILE[/b] [c]{cond}[/c]</source>
         <translation>[b]TANT QUE[/b] [c]{cond}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1991"/>
+        <location filename="../forms/mainwindow.py" line="2018"/>
         <source>[b]IF[/b] [c]{cond}[/c]</source>
         <translation>[b]SI[/b] [c]{cond}[/c]</translation>
     </message>
@@ -110,47 +110,47 @@ p, li { white-space: pre-wrap; }
         <translation type="obsolete">[k]SAISIR[/k] [c]{var}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2022"/>
+        <location filename="../forms/mainwindow.py" line="2049"/>
         <source>[k]RETURN[/k] [c]{val}[/c]</source>
         <translation>[k]RENVOYER[/k] [c]{val}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1999"/>
+        <location filename="../forms/mainwindow.py" line="2026"/>
         <source>[k]DECLARE[/k] [c]{var}[/c]</source>
         <translation>[k]DÉCLARER[/k] [c]{var}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2008"/>
+        <location filename="../forms/mainwindow.py" line="2035"/>
         <source>[k]CALL[/k] [c]{code}[/c]</source>
         <translation>[k]APPELER[/k] [c]{code}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2018"/>
+        <location filename="../forms/mainwindow.py" line="2045"/>
         <source>[b]FUNCTION[/b] [c]{func}({args})[/c]</source>
         <translation>[b]FONCTION[/b] [c]{func}({args})[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2078"/>
+        <location filename="../forms/mainwindow.py" line="2105"/>
         <source>[b]PROGRAM[/b]</source>
         <translation>[b]ALGORITHME[/b]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1979"/>
+        <location filename="../forms/mainwindow.py" line="2006"/>
         <source>[k]BREAK[/k]</source>
         <translation>[k]SORTIR[/k]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2011"/>
+        <location filename="../forms/mainwindow.py" line="2038"/>
         <source>[b]FOR[/b] [c]{var}[/c] [b]FROM[/b] [c]{begin}[/c] [b]TO[/b] [c]{end}[/c] {step}</source>
         <translation>[b]POUR[/b] [c]{var}[/c] [b]DE[/b] [c]{begin}[/c] [b]À[/b] [c]{end}[/c] {step}</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2012"/>
+        <location filename="../forms/mainwindow.py" line="2039"/>
         <source>([b]STEP[/b] [c]{step}[/c])</source>
         <translation>([b]PAS[/b] [c]{step}[/c])</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2081"/>
+        <location filename="../forms/mainwindow.py" line="2108"/>
         <source>[i]empty[/i]</source>
         <translation>[i]vide[/i]</translation>
     </message>
@@ -194,57 +194,57 @@ p, li { white-space: pre-wrap; }
         <translation>Cible d&apos;affectation invalide (doit être une variable ou un élément de liste) : {name}</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2001"/>
+        <location filename="../forms/mainwindow.py" line="2028"/>
         <source>[k]VARIABLE[/k] [c]{var}[/c] [k]TAKES VALUE[/k] [c]{value}[/c]</source>
         <translation>[k]VARIABLE[/k] [c]{var}[/c] [k]PREND LA VALEUR[/b] [c]{value}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2036"/>
+        <location filename="../forms/mainwindow.py" line="2063"/>
         <source>[k]CLEAR PLOT[/k]</source>
         <translation>[k]EFFACER GRAPHIQUE[/k]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2039"/>
+        <location filename="../forms/mainwindow.py" line="2066"/>
         <source>[k]DRAW LINE[/k] [c]{color}[/c] [k]FROM[/k] ([c]{start_x}[/c]; [c]{start_y}[/c]) [k]TO[/k] ([c]{end_x}[/c]; [c]{end_y}[/c])</source>
         <translation>[k]DESSINER LIGNE[/k] [c]{color}[/c] [k]DE[/k] ([c]{start_x}[/c]; [c]{start_y}[/c]) [k]À[/k] ([c]{end_x}[/c]; [c]{end_y}[/c])</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2049"/>
+        <location filename="../forms/mainwindow.py" line="2076"/>
         <source>[k]DRAW POINT[/k] [c]{color}[/c] [k]AT[/k] ([c]{x}[/c]; [c]{y}[/c])</source>
         <translation>[k]DESSINER POINT[/k] [c]{color}[/c] [k]À[/k] ([c]{x}[/c]; [c]{y}[/c])</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2056"/>
+        <location filename="../forms/mainwindow.py" line="2083"/>
         <source>[k]SET WINDOW[/k] [i]Xmin=[/i][c]{x_min}[/c] [i]Xmax=[/i][c]{x_max}[/c] [i]Ymin=[/i][c]{y_min}[/c] [i]Ymax=[/i][c]{y_max}[/c] [i]Xgrad=[/i][c]{x_grad}[/c] [i]Ygrad=[/i][c]{y_grad}[/c]</source>
         <translation>[k]DÉFINIR REPÈRE[/k] [i]Xmin=[/i][c]{x_min}[/c] [i]Xmax=[/i][c]{x_max}[/c] [i]Ymin=[/i][c]{y_min}[/c] [i]Ymax=[/i][c]{y_max}[/c] [i]Xgrad=[/i][c]{x_grad}[/c] [i]Ygrad=[/i][c]{y_grad}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2026"/>
+        <location filename="../forms/mainwindow.py" line="2053"/>
         <source>[k]STOP[/k] [c]{val}[/c]</source>
         <translation>[k]STOP[/k] [c]{val}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2067"/>
+        <location filename="../forms/mainwindow.py" line="2094"/>
         <source>[k]PLOT FUNCTION[/k] [c]{color}[/c] [i]f[/i]({var}) = [c]{expr}[/c] [k]FROM[/k] [c]{begin}[/c] [k]TO[/k] [c]{end}[/c] [k]STEP[/k] [c]{step}[/c]</source>
         <translation>[k]TRACER FONCTION[/k] [c]{color}[/c] [i]f[/i]({var}) = [c]{expr}[/c] [k]DE[/k] [c]{begin}[/c] [k]À[/k] [c]{end}[/c] [k]PAS[/k] [c]{step}[/c]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2030"/>
+        <location filename="../forms/mainwindow.py" line="2057"/>
         <source>[k]WAIT[/k] [c]{val}[/c] [k]SECONDS[/k]</source>
         <translation>[k]ATTENDRE[/k] [c]{val}[/c] [k]SECONDES[/k]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1976"/>
+        <location filename="../forms/mainwindow.py" line="2003"/>
         <source>[k]DISPLAY[/k] [c]{val}[/c] {newline}</source>
         <translation>[k]AFFICHER[/k] [c]{val}[/c] {newline}</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1994"/>
+        <location filename="../forms/mainwindow.py" line="2021"/>
         <source>[k]INPUT[/k] [c]{prompt}[/c] [k]TO[/k] [c]{var}[/c] {text}</source>
         <translation>[k]SAISIR[/k] [c]{var}[/c] {text}</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2001"/>
+        <location filename="../forms/mainwindow.py" line="2028"/>
         <source>[c]{var}[/c] [k]&amp;#129128;[/k] [c]{value}[/c]</source>
         <translation>[c]{var}[/c] [k]&amp;#129128;[/k] [c]{value}[/c]</translation>
     </message>
@@ -1507,36 +1507,6 @@ désactivé :</translation>
         <source>Returns the lowercase version of {{s}}.</source>
         <translation>Renvoie une copie en minuscules de {{s}}.</translation>
     </message>
-    <message>
-        <location filename="../maths/lib/stats.py" line="565"/>
-        <source>Returns the probability for {{x}} with the normal distribution of parameters &#xb5;={{mu}} and ?={{sigma}}.</source>
-        <translation type="obsolete">Renvoie la probabilité de {{x}} avec la loi normale de paramètres µ={{mu}} et σ={{sigma}}.</translation>
-    </message>
-    <message>
-        <location filename="../maths/lib/stats.py" line="580"/>
-        <source>Returns the probability for {{x}} with the standard normal distribution (&#xb5;=0 and ?=1).</source>
-        <translation type="obsolete">Renvoie la probabilité de {{x}} avec la loi normale centrée réduite (µ=0 et σ=1).</translation>
-    </message>
-    <message>
-        <location filename="../maths/lib/stats.py" line="591"/>
-        <source>Returns the cumulative probability for {{x}} with the normal distribution of parameters &#xb5;={{mu}} and ?={{sigma}}.</source>
-        <translation type="obsolete">Renvoie la probabilité cumulative de {{x}} avec la loi normale de paramètres µ={{mu}} et σ={{sigma}}.</translation>
-    </message>
-    <message>
-        <location filename="../maths/lib/stats.py" line="605"/>
-        <source>Returns the cumulative probability for {{x}} with the standard normal distribution (&#xb5;=0 and ?=1).</source>
-        <translation type="obsolete">Renvoie la probabilité cumulative de {{x}} avec la loi normale centrée réduite (µ=0 et σ=1).</translation>
-    </message>
-    <message>
-        <location filename="../maths/lib/stats.py" line="617"/>
-        <source>Returns the number with cumulative probability {{p}} with the normal distribution of parameters &#xb5;={{mu}} and ?={{sigma}}.</source>
-        <translation type="obsolete">Renvoie le nombre ayant pour probabilité cumulative {{p}} avec la loi normale de paramètres µ={{mu}} et σ={{sigma}}.</translation>
-    </message>
-    <message>
-        <location filename="../maths/lib/stats.py" line="631"/>
-        <source>Returns the number with cumulative probability {{p}} with the standard normal distribution (&#xb5;=0 and ?=1).</source>
-        <translation type="obsolete">Renvoie le nombre ayant pour probabilité cumulative {{p}} avec la loi normale centrée réduite (µ=0 et σ=1).</translation>
-    </message>
     <message encoding="UTF-8">
         <location filename="../maths/lib/stats.py" line="565"/>
         <source>Returns the probability for {{x}} with the normal distribution of parameters µ={{mu}} and σ={{sigma}}.</source>
@@ -1890,7 +1860,7 @@ désactivé :</translation>
         <translation>Convertir en pseudocode</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="354"/>
+        <location filename="../forms/mainwindow.py" line="355"/>
         <source>Do you really want to exit?
 All unsaved changes will be lost.</source>
         <translation>Voulez-vous vraiment quitter ?
@@ -1917,17 +1887,17 @@ Toutes les modifications non sauvegardées seront perdues.</translation>
         <translation>Code</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="729"/>
+        <location filename="../forms/mainwindow.py" line="730"/>
         <source>end of output</source>
         <translation>fin de l&apos;exécution</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="551"/>
+        <location filename="../forms/mainwindow.py" line="552"/>
         <source>Input: </source>
         <translation>Saisir : </translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="919"/>
+        <location filename="../forms/mainwindow.py" line="920"/>
         <source>Syntax error ({type}) at line {line}, offset {off}: </source>
         <translation>Erreur de syntaxe ({type}) à la ligne {line}, caractère {off} : </translation>
     </message>
@@ -2027,27 +1997,27 @@ Toutes les modifications non sauvegardées seront perdues.</translation>
         <translation>Commentaire</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="785"/>
+        <location filename="../forms/mainwindow.py" line="786"/>
         <source>program interrupted</source>
         <translation>algorithme interrompu</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="729"/>
+        <location filename="../forms/mainwindow.py" line="730"/>
         <source>end of output [{time}]</source>
         <translation>fin de l&apos;exécution [{time}]</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2324"/>
+        <location filename="../forms/mainwindow.py" line="2351"/>
         <source>Python file (*.py)</source>
         <translation>Fichier Python (*.py)</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2325"/>
+        <location filename="../forms/mainwindow.py" line="2352"/>
         <source>Turing program (*.tr)</source>
         <translation>Algorithme Turing (*.tr)</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2326"/>
+        <location filename="../forms/mainwindow.py" line="2353"/>
         <source>Algobox file (*.alg)</source>
         <translation>Algorithme Algobox (*.alg)</translation>
     </message>
@@ -2082,17 +2052,17 @@ Toutes les modifications non sauvegardées seront perdues.</translation>
         <translation>AFFICHER valeur</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="388"/>
+        <location filename="../forms/mainwindow.py" line="389"/>
         <source>Turing - New File</source>
         <translation>Turing - Sans titre</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="384"/>
+        <location filename="../forms/mainwindow.py" line="385"/>
         <source>Turing - {file} (unsaved)</source>
         <translation>Turing - {file} (modifié)</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="386"/>
+        <location filename="../forms/mainwindow.py" line="387"/>
         <source>Turing - {file}</source>
         <translation>Turing - {file}</translation>
     </message>
@@ -2102,7 +2072,7 @@ Toutes les modifications non sauvegardées seront perdues.</translation>
         <translation>Déboguer</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2323"/>
+        <location filename="../forms/mainwindow.py" line="2350"/>
         <source>Program file (*.py *.tr *.alg)</source>
         <translation>Fichier de programme (*.py *.tr *.alg)</translation>
     </message>
@@ -2132,17 +2102,17 @@ Toutes les modifications non sauvegardées seront perdues.</translation>
         <translation>Définir le repère</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1046"/>
+        <location filename="../forms/mainwindow.py" line="1062"/>
         <source>Save output</source>
         <translation>Enregistrer la sortie</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1046"/>
+        <location filename="../forms/mainwindow.py" line="1062"/>
         <source>Text files (*.txt)</source>
         <translation>Fichiers texte (*.txt)</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1121"/>
+        <location filename="../forms/mainwindow.py" line="1148"/>
         <source>Do you really want to create a new file?
 All unsaved changes will be lost.</source>
         <translation>Voulez-vous vraiment créer un nouveau fichier ?
@@ -2154,7 +2124,7 @@ Toutes les modifications non sauvegardées seront perdues.</translation>
         <translation>Un commentaire ?</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2490"/>
+        <location filename="../forms/mainwindow.py" line="2517"/>
         <source>A new version of Turing is available.
 Would you like to download it?</source>
         <translation>Une nouvelle version de Turing est disponible.
@@ -2166,7 +2136,7 @@ Voulez-vous la télécharger ?</translation>
         <translation>Point d&apos;arrêt</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="754"/>
+        <location filename="../forms/mainwindow.py" line="755"/>
         <source>Breakpoint: </source>
         <translation>Point d&apos;arrêt : </translation>
     </message>
@@ -2186,7 +2156,7 @@ Voulez-vous la télécharger ?</translation>
         <translation>Par défaut</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1304"/>
+        <location filename="../forms/mainwindow.py" line="1331"/>
         <source>Advanced</source>
         <translation>Avancé</translation>
     </message>
@@ -2207,82 +2177,82 @@ Voulez-vous la télécharger ?</translation>
         <translation>Dupliquer</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1307"/>
+        <location filename="../forms/mainwindow.py" line="1334"/>
         <source>Folding</source>
         <translation>Plan</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1308"/>
+        <location filename="../forms/mainwindow.py" line="1335"/>
         <source>Collapse</source>
         <translation>Réduire</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1309"/>
+        <location filename="../forms/mainwindow.py" line="1336"/>
         <source>Expand</source>
         <translation>Étendre</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1311"/>
+        <location filename="../forms/mainwindow.py" line="1338"/>
         <source>Expand all</source>
         <translation>Tout étendre</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1313"/>
+        <location filename="../forms/mainwindow.py" line="1340"/>
         <source>Select word</source>
         <translation>Sélectionner le mot</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1314"/>
+        <location filename="../forms/mainwindow.py" line="1341"/>
         <source>Select extended word</source>
         <translation>Sélectionner le mot étendu</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1315"/>
+        <location filename="../forms/mainwindow.py" line="1342"/>
         <source>Matched select</source>
         <translation>Sélectionner le résultat</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1316"/>
+        <location filename="../forms/mainwindow.py" line="1343"/>
         <source>Select line</source>
         <translation>Sélectionner la ligne</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1317"/>
+        <location filename="../forms/mainwindow.py" line="1344"/>
         <source>Select</source>
         <translation>Sélection</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1310"/>
+        <location filename="../forms/mainwindow.py" line="1337"/>
         <source>Collapse all</source>
         <translation>Tout réduire</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1327"/>
+        <location filename="../forms/mainwindow.py" line="1354"/>
         <source>Regex</source>
         <translation>Expression régulière</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1328"/>
+        <location filename="../forms/mainwindow.py" line="1355"/>
         <source>Match case</source>
         <translation>Respecter la casse</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1329"/>
+        <location filename="../forms/mainwindow.py" line="1356"/>
         <source>Whole words</source>
         <translation>Mot entier</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1330"/>
+        <location filename="../forms/mainwindow.py" line="1357"/>
         <source>In Selection</source>
         <translation>Dans la sélection</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1331"/>
+        <location filename="../forms/mainwindow.py" line="1358"/>
         <source>0 matches</source>
         <translation>0 correspondances</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1333"/>
+        <location filename="../forms/mainwindow.py" line="1360"/>
         <source>Replace All</source>
         <translation>Remplacer tout</translation>
     </message>
@@ -2312,19 +2282,19 @@ Voulez-vous la télécharger ?</translation>
         <translation>Attendre</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1421"/>
+        <location filename="../forms/mainwindow.py" line="1448"/>
         <source>{num} matches</source>
         <translation>{num} correspondances</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2500"/>
+        <location filename="../forms/mainwindow.py" line="2527"/>
         <source>A modified file has been automatically saved.
 Would you like to recover it?</source>
         <translation>Un fichier modifié a été enregistré automatiquement.
 Souhaitez-vous le récupérer ?</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1305"/>
+        <location filename="../forms/mainwindow.py" line="1332"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
@@ -2375,6 +2345,22 @@ Souhaitez-vous le récupérer ?</translation>
         <location filename="../forms/ui_mainwindow.py" line="964"/>
         <source>Check for updates</source>
         <translation>Vérifier les mises à jour</translation>
+    </message>
+    <message>
+        <location filename="../forms/mainwindow.py" line="1010"/>
+        <source>You are about to choose an example file
+from the `examples` directory. To guess what examples are,
+you can guess from the file names.</source>
+        <translation>Vous allez choisir un fichier d&apos;exemple
+depuis le répertoire « examples ». Pour devinece qu&apos;il y a
+dans les fichiers, fiez-vous à leurs noms.</translation>
+    </message>
+    <message>
+        <location filename="../forms/mainwindow.py" line="1090"/>
+        <source>You are not allowed to write to {},
+please choose another file path.</source>
+        <translation>Vous n&apos;êtes pas autorisé à écrire dans {},
+veuillez choisir un chemin vers un autre fichier.</translation>
     </message>
 </context>
 <context>

--- a/src/lang/it.ts
+++ b/src/lang/it.ts
@@ -38,97 +38,97 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>Algo</name>
     <message>
-        <location filename="../forms/mainwindow.py" line="1979"/>
+        <location filename="../forms/mainwindow.py" line="2006"/>
         <source>[k]BREAK[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1982"/>
+        <location filename="../forms/mainwindow.py" line="2009"/>
         <source>[k]CONTINUE[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1985"/>
+        <location filename="../forms/mainwindow.py" line="2012"/>
         <source>[b]ELSE[/b]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1988"/>
+        <location filename="../forms/mainwindow.py" line="2015"/>
         <source>[b]WHILE[/b] [c]{cond}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1991"/>
+        <location filename="../forms/mainwindow.py" line="2018"/>
         <source>[b]IF[/b] [c]{cond}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1999"/>
+        <location filename="../forms/mainwindow.py" line="2026"/>
         <source>[k]DECLARE[/k] [c]{var}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2008"/>
+        <location filename="../forms/mainwindow.py" line="2035"/>
         <source>[k]CALL[/k] [c]{code}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2011"/>
+        <location filename="../forms/mainwindow.py" line="2038"/>
         <source>[b]FOR[/b] [c]{var}[/c] [b]FROM[/b] [c]{begin}[/c] [b]TO[/b] [c]{end}[/c] {step}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2012"/>
+        <location filename="../forms/mainwindow.py" line="2039"/>
         <source>([b]STEP[/b] [c]{step}[/c])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2018"/>
+        <location filename="../forms/mainwindow.py" line="2045"/>
         <source>[b]FUNCTION[/b] [c]{func}({args})[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2022"/>
+        <location filename="../forms/mainwindow.py" line="2049"/>
         <source>[k]RETURN[/k] [c]{val}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2026"/>
+        <location filename="../forms/mainwindow.py" line="2053"/>
         <source>[k]STOP[/k] [c]{val}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2030"/>
+        <location filename="../forms/mainwindow.py" line="2057"/>
         <source>[k]WAIT[/k] [c]{val}[/c] [k]SECONDS[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2036"/>
+        <location filename="../forms/mainwindow.py" line="2063"/>
         <source>[k]CLEAR PLOT[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2039"/>
+        <location filename="../forms/mainwindow.py" line="2066"/>
         <source>[k]DRAW LINE[/k] [c]{color}[/c] [k]FROM[/k] ([c]{start_x}[/c]; [c]{start_y}[/c]) [k]TO[/k] ([c]{end_x}[/c]; [c]{end_y}[/c])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2049"/>
+        <location filename="../forms/mainwindow.py" line="2076"/>
         <source>[k]DRAW POINT[/k] [c]{color}[/c] [k]AT[/k] ([c]{x}[/c]; [c]{y}[/c])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2067"/>
+        <location filename="../forms/mainwindow.py" line="2094"/>
         <source>[k]PLOT FUNCTION[/k] [c]{color}[/c] [i]f[/i]({var}) = [c]{expr}[/c] [k]FROM[/k] [c]{begin}[/c] [k]TO[/k] [c]{end}[/c] [k]STEP[/k] [c]{step}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2078"/>
+        <location filename="../forms/mainwindow.py" line="2105"/>
         <source>[b]PROGRAM[/b]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2081"/>
+        <location filename="../forms/mainwindow.py" line="2108"/>
         <source>[i]empty[/i]</source>
         <translation type="unfinished"></translation>
     </message>
@@ -200,27 +200,27 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2056"/>
+        <location filename="../forms/mainwindow.py" line="2083"/>
         <source>[k]SET WINDOW[/k] [i]Xmin=[/i][c]{x_min}[/c] [i]Xmax=[/i][c]{x_max}[/c] [i]Ymin=[/i][c]{y_min}[/c] [i]Ymax=[/i][c]{y_max}[/c] [i]Xgrad=[/i][c]{x_grad}[/c] [i]Ygrad=[/i][c]{y_grad}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2001"/>
+        <location filename="../forms/mainwindow.py" line="2028"/>
         <source>[k]VARIABLE[/k] [c]{var}[/c] [k]TAKES VALUE[/k] [c]{value}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1976"/>
+        <location filename="../forms/mainwindow.py" line="2003"/>
         <source>[k]DISPLAY[/k] [c]{val}[/c] {newline}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1994"/>
+        <location filename="../forms/mainwindow.py" line="2021"/>
         <source>[k]INPUT[/k] [c]{prompt}[/c] [k]TO[/k] [c]{var}[/c] {text}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2001"/>
+        <location filename="../forms/mainwindow.py" line="2028"/>
         <source>[c]{var}[/c] [k]&amp;#129128;[/k] [c]{value}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2068,195 +2068,195 @@ Window Text :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="354"/>
+        <location filename="../forms/mainwindow.py" line="355"/>
         <source>Do you really want to exit?
 All unsaved changes will be lost.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="384"/>
+        <location filename="../forms/mainwindow.py" line="385"/>
         <source>Turing - {file} (unsaved)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="386"/>
+        <location filename="../forms/mainwindow.py" line="387"/>
         <source>Turing - {file}</source>
         <translation>Turing - {file}</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="388"/>
+        <location filename="../forms/mainwindow.py" line="389"/>
         <source>Turing - New File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="551"/>
+        <location filename="../forms/mainwindow.py" line="552"/>
         <source>Input: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="729"/>
+        <location filename="../forms/mainwindow.py" line="730"/>
         <source>end of output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="729"/>
+        <location filename="../forms/mainwindow.py" line="730"/>
         <source>end of output [{time}]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="754"/>
+        <location filename="../forms/mainwindow.py" line="755"/>
         <source>Breakpoint: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="785"/>
+        <location filename="../forms/mainwindow.py" line="786"/>
         <source>program interrupted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="919"/>
+        <location filename="../forms/mainwindow.py" line="920"/>
         <source>Syntax error ({type}) at line {line}, offset {off}: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1046"/>
+        <location filename="../forms/mainwindow.py" line="1062"/>
         <source>Save output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1046"/>
+        <location filename="../forms/mainwindow.py" line="1062"/>
         <source>Text files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1121"/>
+        <location filename="../forms/mainwindow.py" line="1148"/>
         <source>Do you really want to create a new file?
 All unsaved changes will be lost.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1304"/>
+        <location filename="../forms/mainwindow.py" line="1331"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1305"/>
+        <location filename="../forms/mainwindow.py" line="1332"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1307"/>
+        <location filename="../forms/mainwindow.py" line="1334"/>
         <source>Folding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1308"/>
+        <location filename="../forms/mainwindow.py" line="1335"/>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1309"/>
+        <location filename="../forms/mainwindow.py" line="1336"/>
         <source>Expand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1310"/>
+        <location filename="../forms/mainwindow.py" line="1337"/>
         <source>Collapse all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1311"/>
+        <location filename="../forms/mainwindow.py" line="1338"/>
         <source>Expand all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1313"/>
+        <location filename="../forms/mainwindow.py" line="1340"/>
         <source>Select word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1314"/>
+        <location filename="../forms/mainwindow.py" line="1341"/>
         <source>Select extended word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1315"/>
+        <location filename="../forms/mainwindow.py" line="1342"/>
         <source>Matched select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1316"/>
+        <location filename="../forms/mainwindow.py" line="1343"/>
         <source>Select line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1317"/>
+        <location filename="../forms/mainwindow.py" line="1344"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1327"/>
+        <location filename="../forms/mainwindow.py" line="1354"/>
         <source>Regex</source>
         <translation>Espressione regolare</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1328"/>
+        <location filename="../forms/mainwindow.py" line="1355"/>
         <source>Match case</source>
         <translation>L&apos;evidenziazione è case-sensitive</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1329"/>
+        <location filename="../forms/mainwindow.py" line="1356"/>
         <source>Whole words</source>
         <translation>Identifica solo parole intere</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1330"/>
+        <location filename="../forms/mainwindow.py" line="1357"/>
         <source>In Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1331"/>
+        <location filename="../forms/mainwindow.py" line="1358"/>
         <source>0 matches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1333"/>
+        <location filename="../forms/mainwindow.py" line="1360"/>
         <source>Replace All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1421"/>
+        <location filename="../forms/mainwindow.py" line="1448"/>
         <source>{num} matches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2323"/>
+        <location filename="../forms/mainwindow.py" line="2350"/>
         <source>Program file (*.py *.tr *.alg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2324"/>
+        <location filename="../forms/mainwindow.py" line="2351"/>
         <source>Python file (*.py)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2325"/>
+        <location filename="../forms/mainwindow.py" line="2352"/>
         <source>Turing program (*.tr)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2326"/>
+        <location filename="../forms/mainwindow.py" line="2353"/>
         <source>Algobox file (*.alg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2490"/>
+        <location filename="../forms/mainwindow.py" line="2517"/>
         <source>A new version of Turing is available.
 Would you like to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2500"/>
+        <location filename="../forms/mainwindow.py" line="2527"/>
         <source>A modified file has been automatically saved.
 Would you like to recover it?</source>
         <translation type="unfinished"></translation>
@@ -2307,6 +2307,19 @@ Would you like to recover it?</source>
     <message>
         <location filename="../forms/ui_mainwindow.py" line="964"/>
         <source>Check for updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/mainwindow.py" line="1010"/>
+        <source>You are about to choose an example file
+from the `examples` directory. To guess what examples are,
+you can guess from the file names.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/mainwindow.py" line="1090"/>
+        <source>You are not allowed to write to {},
+please choose another file path.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -38,97 +38,97 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>Algo</name>
     <message>
-        <location filename="../forms/mainwindow.py" line="1979"/>
+        <location filename="../forms/mainwindow.py" line="2006"/>
         <source>[k]BREAK[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1982"/>
+        <location filename="../forms/mainwindow.py" line="2009"/>
         <source>[k]CONTINUE[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1985"/>
+        <location filename="../forms/mainwindow.py" line="2012"/>
         <source>[b]ELSE[/b]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1988"/>
+        <location filename="../forms/mainwindow.py" line="2015"/>
         <source>[b]WHILE[/b] [c]{cond}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1991"/>
+        <location filename="../forms/mainwindow.py" line="2018"/>
         <source>[b]IF[/b] [c]{cond}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1999"/>
+        <location filename="../forms/mainwindow.py" line="2026"/>
         <source>[k]DECLARE[/k] [c]{var}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2008"/>
+        <location filename="../forms/mainwindow.py" line="2035"/>
         <source>[k]CALL[/k] [c]{code}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2011"/>
+        <location filename="../forms/mainwindow.py" line="2038"/>
         <source>[b]FOR[/b] [c]{var}[/c] [b]FROM[/b] [c]{begin}[/c] [b]TO[/b] [c]{end}[/c] {step}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2012"/>
+        <location filename="../forms/mainwindow.py" line="2039"/>
         <source>([b]STEP[/b] [c]{step}[/c])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2018"/>
+        <location filename="../forms/mainwindow.py" line="2045"/>
         <source>[b]FUNCTION[/b] [c]{func}({args})[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2022"/>
+        <location filename="../forms/mainwindow.py" line="2049"/>
         <source>[k]RETURN[/k] [c]{val}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2026"/>
+        <location filename="../forms/mainwindow.py" line="2053"/>
         <source>[k]STOP[/k] [c]{val}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2030"/>
+        <location filename="../forms/mainwindow.py" line="2057"/>
         <source>[k]WAIT[/k] [c]{val}[/c] [k]SECONDS[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2036"/>
+        <location filename="../forms/mainwindow.py" line="2063"/>
         <source>[k]CLEAR PLOT[/k]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2039"/>
+        <location filename="../forms/mainwindow.py" line="2066"/>
         <source>[k]DRAW LINE[/k] [c]{color}[/c] [k]FROM[/k] ([c]{start_x}[/c]; [c]{start_y}[/c]) [k]TO[/k] ([c]{end_x}[/c]; [c]{end_y}[/c])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2049"/>
+        <location filename="../forms/mainwindow.py" line="2076"/>
         <source>[k]DRAW POINT[/k] [c]{color}[/c] [k]AT[/k] ([c]{x}[/c]; [c]{y}[/c])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2067"/>
+        <location filename="../forms/mainwindow.py" line="2094"/>
         <source>[k]PLOT FUNCTION[/k] [c]{color}[/c] [i]f[/i]({var}) = [c]{expr}[/c] [k]FROM[/k] [c]{begin}[/c] [k]TO[/k] [c]{end}[/c] [k]STEP[/k] [c]{step}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2078"/>
+        <location filename="../forms/mainwindow.py" line="2105"/>
         <source>[b]PROGRAM[/b]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2081"/>
+        <location filename="../forms/mainwindow.py" line="2108"/>
         <source>[i]empty[/i]</source>
         <translation type="unfinished"></translation>
     </message>
@@ -200,27 +200,27 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2056"/>
+        <location filename="../forms/mainwindow.py" line="2083"/>
         <source>[k]SET WINDOW[/k] [i]Xmin=[/i][c]{x_min}[/c] [i]Xmax=[/i][c]{x_max}[/c] [i]Ymin=[/i][c]{y_min}[/c] [i]Ymax=[/i][c]{y_max}[/c] [i]Xgrad=[/i][c]{x_grad}[/c] [i]Ygrad=[/i][c]{y_grad}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2001"/>
+        <location filename="../forms/mainwindow.py" line="2028"/>
         <source>[k]VARIABLE[/k] [c]{var}[/c] [k]TAKES VALUE[/k] [c]{value}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1976"/>
+        <location filename="../forms/mainwindow.py" line="2003"/>
         <source>[k]DISPLAY[/k] [c]{val}[/c] {newline}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1994"/>
+        <location filename="../forms/mainwindow.py" line="2021"/>
         <source>[k]INPUT[/k] [c]{prompt}[/c] [k]TO[/k] [c]{var}[/c] {text}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2001"/>
+        <location filename="../forms/mainwindow.py" line="2028"/>
         <source>[c]{var}[/c] [k]&amp;#129128;[/k] [c]{value}[/c]</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2068,196 +2068,196 @@ Window Text :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="354"/>
+        <location filename="../forms/mainwindow.py" line="355"/>
         <source>Do you really want to exit?
 All unsaved changes will be lost.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="384"/>
+        <location filename="../forms/mainwindow.py" line="385"/>
         <source>Turing - {file} (unsaved)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="386"/>
+        <location filename="../forms/mainwindow.py" line="387"/>
         <source>Turing - {file}</source>
         <translation>Turing - {file}</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="388"/>
+        <location filename="../forms/mainwindow.py" line="389"/>
         <source>Turing - New File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="551"/>
+        <location filename="../forms/mainwindow.py" line="552"/>
         <source>Input: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="729"/>
+        <location filename="../forms/mainwindow.py" line="730"/>
         <source>end of output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="729"/>
+        <location filename="../forms/mainwindow.py" line="730"/>
         <source>end of output [{time}]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="754"/>
+        <location filename="../forms/mainwindow.py" line="755"/>
         <source>Breakpoint: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="785"/>
+        <location filename="../forms/mainwindow.py" line="786"/>
         <source>program interrupted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="919"/>
+        <location filename="../forms/mainwindow.py" line="920"/>
         <source>Syntax error ({type}) at line {line}, offset {off}: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1046"/>
+        <location filename="../forms/mainwindow.py" line="1062"/>
         <source>Save output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1046"/>
+        <location filename="../forms/mainwindow.py" line="1062"/>
         <source>Text files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1121"/>
+        <location filename="../forms/mainwindow.py" line="1148"/>
         <source>Do you really want to create a new file?
 All unsaved changes will be lost.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1304"/>
+        <location filename="../forms/mainwindow.py" line="1331"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1307"/>
+        <location filename="../forms/mainwindow.py" line="1334"/>
         <source>Folding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1308"/>
+        <location filename="../forms/mainwindow.py" line="1335"/>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1309"/>
+        <location filename="../forms/mainwindow.py" line="1336"/>
         <source>Expand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1310"/>
+        <location filename="../forms/mainwindow.py" line="1337"/>
         <source>Collapse all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1311"/>
+        <location filename="../forms/mainwindow.py" line="1338"/>
         <source>Expand all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1313"/>
+        <location filename="../forms/mainwindow.py" line="1340"/>
         <source>Select word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1314"/>
+        <location filename="../forms/mainwindow.py" line="1341"/>
         <source>Select extended word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1315"/>
+        <location filename="../forms/mainwindow.py" line="1342"/>
         <source>Matched select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1316"/>
+        <location filename="../forms/mainwindow.py" line="1343"/>
         <source>Select line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1317"/>
+        <location filename="../forms/mainwindow.py" line="1344"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1327"/>
+        <location filename="../forms/mainwindow.py" line="1354"/>
         <source>Regex</source>
         <translation>正则表达式</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1328"/>
+        <location filename="../forms/mainwindow.py" line="1355"/>
         <source>Match case</source>
         <translation>区分大小写</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1329"/>
+        <location filename="../forms/mainwindow.py" line="1356"/>
         <source>Whole words</source>
         <translation>仅匹配完整词</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1330"/>
+        <location filename="../forms/mainwindow.py" line="1357"/>
         <source>In Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1331"/>
+        <location filename="../forms/mainwindow.py" line="1358"/>
         <source>0 matches</source>
         <translation>0次匹配</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1333"/>
+        <location filename="../forms/mainwindow.py" line="1360"/>
         <source>Replace All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1421"/>
+        <location filename="../forms/mainwindow.py" line="1448"/>
         <source>{num} matches</source>
         <translation>{num}次匹配</translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2323"/>
+        <location filename="../forms/mainwindow.py" line="2350"/>
         <source>Program file (*.py *.tr *.alg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2324"/>
+        <location filename="../forms/mainwindow.py" line="2351"/>
         <source>Python file (*.py)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2325"/>
+        <location filename="../forms/mainwindow.py" line="2352"/>
         <source>Turing program (*.tr)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2326"/>
+        <location filename="../forms/mainwindow.py" line="2353"/>
         <source>Algobox file (*.alg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2490"/>
+        <location filename="../forms/mainwindow.py" line="2517"/>
         <source>A new version of Turing is available.
 Would you like to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="2500"/>
+        <location filename="../forms/mainwindow.py" line="2527"/>
         <source>A modified file has been automatically saved.
 Would you like to recover it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/mainwindow.py" line="1305"/>
+        <location filename="../forms/mainwindow.py" line="1332"/>
         <source>Zoom</source>
         <translation>缩放</translation>
     </message>
@@ -2307,6 +2307,19 @@ Would you like to recover it?</source>
     <message>
         <location filename="../forms/ui_mainwindow.py" line="964"/>
         <source>Check for updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/mainwindow.py" line="1010"/>
+        <source>You are about to choose an example file
+from the `examples` directory. To guess what examples are,
+you can guess from the file names.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/mainwindow.py" line="1090"/>
+        <source>You are not allowed to write to {},
+please choose another file path.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import traceback
+import traceback, os
 from typing import Union, List, Iterable
 
 number = Union[int, float, complex]
@@ -37,3 +37,13 @@ def get_short_lang(lang):
 def show_error():
     traceback.print_exc()
     # print(translate("MainWindow", "Error: ") + str(sys.exc_info()[1]) + "\n" + str(sys.exc_info()[2]))
+
+def firstFoundDir(dirList):
+    """
+    @return the first exisiting directory out of a list of available
+    directories, or "." as a fallback.
+    """
+    for d in dirList:
+        if os.path.isdir(d):
+            return d
+    return "."


### PR DESCRIPTION
L'action aide->exemples est implémentée ainsi : 
1- un message avertit le débutant qu'il va choisir parmi des fichiers, et que les noms des fichiers suggèrent ce qu'ils font (plus tard, peut-être que quelqu'un injectera plus de métadonnées et qu'on pourra proposer une information mieux structurée aux débutants !)
2- le choix des fichiers est issu du répertoire examples, recherché en priorité dans une zone partagée au sein du système de fichiers
3- l'utilisateur choisit un fichier et celui-ci est ouvert

N.B.: pour Debian, le répertoire sera trouvé d'abord dans /usr/share/turing, qui est une zone *non inscriptible par tous*, donc l'action d'enregistrement échouerait. J'ai donc un peu sophistiqué la fonction handler_save pour signaler les échecs à l'écriture. Normalement si Turing devient un vrai paquet pour Windows, il se trouve que Windows est aussi un système multi-utilisateur, et que donc dans certaines conditions, il faudra gérer le même souci (par exemple paquet installé par un Admin, accessibles à tous : dans ce cas les exemples doivent être en lecture seule).